### PR TITLE
Changed open to URI.open() to work correctly on Windows

### DIFF
--- a/lib/jekyll/csv.rb
+++ b/lib/jekyll/csv.rb
@@ -37,7 +37,7 @@ module Jekyll
       end
 
       def csv_string
-        @csv_string ||= open(conf['source']).read
+        @csv_string ||= URI.open(conf['source']).read
       end
 
       def slug_field

--- a/lib/jekyll/csv.rb
+++ b/lib/jekyll/csv.rb
@@ -22,6 +22,7 @@ module Jekyll
           doc.merge_data!(item)
           if site.layouts.key?(collection_name)
             doc.merge_data!({'layout' => collection_name})
+            doc.merge_data!({'slug' => item[slug_field]})
           end
           collection.docs << doc
         end

--- a/lib/jekyll/csv.rb
+++ b/lib/jekyll/csv.rb
@@ -21,7 +21,7 @@ module Jekyll
           doc = Document.new(path, collection: collection, site: site)
           doc.merge_data!(item)
           if site.layouts.key?(collection_name)
-            doc.merge_data!('layout' => collection_name)
+            doc.merge_data!({'layout' => collection_name})
           end
           collection.docs << doc
         end


### PR DESCRIPTION
I received the error `'initialize': Invalid argument @ rb_sysopen` on Windows. According to https://stackoverflow.com/questions/68344911/ruby-invalid-argument-rb-sysopen, we need to fully-qualify the call to `open` as `URI.open()` so it doesn't try to call the `open` from the Kernel class. I also fixed an issue with a call to merge_data to avoid an error, and I added the slug to the generated documents so I can pull information for that particular item in its document.